### PR TITLE
[CLOUD-2051] force a particular OpenJDK version

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -11,7 +11,9 @@ envs:
     - name: "JAVA_VERSION"
       value: "1.8.0"
 packages:
-    - java-1.8.0-openjdk-devel
+    - java-1.8.0-openjdk-1.8.0.141
+    - java-1.8.0-openjdk-headless-1.8.0.141
+    - java-1.8.0-openjdk-devel-1.8.0.141
 dogen:
     version: 2.4.3
     plugins:


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2051

There's a performance regression in OpenJDK ≥ 1.8.0.144. As a
work-around, require the explicit version 1.8.0.141.

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>