### PR TITLE
[CLOUD-2051]: remove pinning

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -22,9 +22,7 @@ packages:
       repositories:
           - jboss-os
       install:
-          - java-1.8.0-openjdk-1.8.0.141
-          - java-1.8.0-openjdk-headless-1.8.0.141
-          - java-1.8.0-openjdk-devel-1.8.0.141
+          - java-1.8.0-openjdk-devel
 run:
       user: 185
 osbs:


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2051

We pinned openjdk to 1.8.0.141 to avoid a performance regression first
noticed in 1.8.0.144; this has now been addressed in 151-1.b12 so we can
remove the pinning. This is necessary to pick up security fixes.

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>